### PR TITLE
Enforce the observation space limits

### DIFF
--- a/mano_pybullet/envs/hand_env.py
+++ b/mano_pybullet/envs/hand_env.py
@@ -194,8 +194,11 @@ class HandEnv(gym.Env):
         Environments will automatically close() themselves when
         garbage collected or when the program exits.
         """
-        if self._client.isConnected():
-            self._client.disconnect()
+        try:
+            if self._client.isConnected():
+                self._client.disconnect()
+        except:
+            return
 
     def seed(self, seed=None):
         """Sets the seed for this env's random number generator(s).

--- a/mano_pybullet/envs/hand_lift_env.py
+++ b/mano_pybullet/envs/hand_lift_env.py
@@ -14,7 +14,7 @@ class HandLiftEnv(HandObjectEnv):
         Keyword Arguments:
             target_height {float} -- target lift height (default: {0.25})
         """
-        super().__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self._target_height = target_height
 
     def reset(self, **kwargs):

--- a/mano_pybullet/hand_body.py
+++ b/mano_pybullet/hand_body.py
@@ -40,6 +40,7 @@ class HandBody:
         """
         self._client = client
         self._model = hand_model
+        self.joint_low, self.joint_high = map(np.float32, self._model.dofs_limits)
         self._flags = flags
         self._vertices = hand_model.vertices(betas=shape_betas)
         self._origin = self._model.origins()[0]
@@ -91,6 +92,7 @@ class HandBody:
             constraint_forces = [0.0] * 6
         joint_states = self._client.getJointStates(self._body_id, self._joint_indices)
         joints_pos, joints_vel, _, joints_torque = zip(*joint_states)
+        joints_pos = tuple(np.clip(joints_pos, self.joint_low, self.joint_high))
         return base_pos, base_orn, constraint_forces, joints_pos, joints_vel, joints_torque
 
     def reset(self, position, orientation, joint_angles=None):
@@ -273,7 +275,8 @@ class HandBody:
                     bodyUniqueId=self._body_id,
                     linkIndex=i,
                     jointLowerLimit=limits[0],
-                    jointUpperLimit=limits[1])
+                    jointUpperLimit=limits[1],
+                    maxJointVelocity=3.0)
 
     def _apply_dynamics(self):
         if self.FLAG_DYNAMICS & self._flags:

--- a/mano_pybullet/hand_body.py
+++ b/mano_pybullet/hand_body.py
@@ -1,5 +1,7 @@
 """Rigid hand body."""
 import contextlib
+import os
+import pathlib
 import tempfile
 
 import numpy as np
@@ -297,11 +299,16 @@ class HandBody:
     @contextlib.contextmanager
     def _temp_link_mesh(self, link_index, collision):
         with tempfile.NamedTemporaryFile('w', suffix='.obj') as temp_file:
-            threshold = 0.2
-            if collision and link_index in [4, 7, 10]:
-                threshold = 0.7
-            vertex_mask = self._model.weights[:, link_index] > threshold
-            vertices, faces = filter_mesh(self._vertices, self._model.faces, vertex_mask)
-            vertices -= self._model.joints[link_index].origin
-            save_mesh_obj(temp_file.name, vertices, faces)
-            yield temp_file.name
+            tmp_folder = str(pathlib.Path(temp_file.name).parent)
+            temp_file.name = temp_file.name.replace(
+                tmp_folder,
+                os.path.join(tmp_folder, "MANO_Pybullet")
+            )
+        threshold = 0.2
+        if collision and link_index in [4, 7, 10]:
+            threshold = 0.7
+        vertex_mask = self._model.weights[:, link_index] > threshold
+        vertices, faces = filter_mesh(self._vertices, self._model.faces, vertex_mask)
+        vertices -= self._model.joints[link_index].origin
+        save_mesh_obj(temp_file.name, vertices, faces)
+        yield temp_file.name


### PR DESCRIPTION
These changes ensure that the observations are always contained in the observation space.
They are needed to run MANO Pybullet with Garage, for example.